### PR TITLE
Fix typo in head causing top margin 

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>CSH Game Tournament 2016</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <link rel="stylesheet" href="dist/css/csh-material-bootstrap.css" media="screen">`
+    <link rel="stylesheet" href="dist/css/csh-material-bootstrap.css" media="screen">
     <link rel="stylesheet" href="dist/css/styles.css" media="screen">
 </head>
 


### PR DESCRIPTION
I'm not sure if others have seen it but there was a unnecessary margin at the top of the page because of a typo in the head tag. 1-character commit changes :shipit: 💯  
